### PR TITLE
Vite config cleanup after Remix stabilized

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,5 @@
 import {
   Links,
-  LiveReload,
   Meta,
   Outlet,
   Scripts,
@@ -20,7 +19,6 @@ export default function App() {
         <Outlet />
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   );
@@ -38,7 +36,6 @@ export function HydrateFallback() {
       <body>
         <p>Loading...</p>
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { unstable_vitePlugin as remix } from "@remix-run/dev";
+import { vitePlugin as remix } from "@remix-run/dev";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix({ unstable_ssr: false }), tsconfigPaths()],
+  plugins: [remix({ ssr: false }), tsconfigPaths()],
 });


### PR DESCRIPTION
Just some quick cleanup I encountered using the starter just now.

* Removed `unstable_` prefixes
* Removed now unused LiveReload component